### PR TITLE
Fix broken images when opening an .EFT file

### DIFF
--- a/WebApp/services/nbis_helper.py
+++ b/WebApp/services/nbis_helper.py
@@ -135,65 +135,30 @@ def get_nfiq_quality(image_path: str) -> int:
 
 def convert_wsq_to_raw(wsq_path: str) -> str:
     """
-    Decodes a WSQ file to a raw file using `dwsq`.
-    
+    Decodes a WSQ file to a bare raw pixmap file using `dwsq`.
+
+    Usage is `dwsq <outext> <image file> [-raw_out]`; the output is always
+    written to `<image file>.<outext>`. Without `-raw_out`, dwsq writes a
+    NIST IHead file instead (a 288-byte text header followed by the pixel
+    data) under that same `.raw` name, which is the wrong format here and
+    throws off any size check against width*height.
+
     Args:
         wsq_path: Path to the WSQ file.
-        
+
     Returns:
-        Path to the decoded raw file.
+        Path to the decoded raw pixmap file.
     """
-    # dwsq <file> creates <file>.raw (stripping extension if present? No, usually adds .raw)
-    # Actually dwsq usuall takes input.wsq and outputs input.raw if no args?
-    # Or dwsq <input> [-raw] ...
-    # From help: dwsq decompresses...
-    # Usage usually: dwsq file.wsq  -> produces file.raw in same dir.
-    
-    # Check if raw already exists
     base = os.path.splitext(wsq_path)[0]
     raw_path = base + ".raw"
-    
-    if os.path.exists(raw_path):
-        return raw_path
-        
-    # Run dwsq
-    # Try 1: dwsq raw <file>
-    command = ["dwsq", "raw", os.path.basename(wsq_path)]
-    stdout, stderr, returncode = run_command(command, cwd=os.path.dirname(wsq_path))
-    
-    if os.path.exists(raw_path):
-        return raw_path
-        
-    # Try 2: dwsq <file> (defaults to .raw output often)
-    command = ["dwsq", os.path.basename(wsq_path)]
-    stdout, stderr, returncode = run_command(command, cwd=os.path.dirname(wsq_path))
-    
-    if os.path.exists(raw_path):
-        return raw_path
-        
-    # Try 3: Append -raw flag if supported
-    command = ["dwsq", "-raw", os.path.basename(wsq_path)]
+
+    command = ["dwsq", "raw", os.path.basename(wsq_path), "-raw_out"]
     stdout, stderr, returncode = run_command(command, cwd=os.path.dirname(wsq_path))
 
     if os.path.exists(raw_path):
         return raw_path
-
-    # Check for file.wsq.raw pattern in case tool appended
-    if os.path.exists(wsq_path + ".raw"):
-         return wsq_path + ".raw"
 
     raise Exception(f"dwsq failed to produce raw file. Last error: {stderr}")
-             
-    # Verify result
-    if os.path.exists(raw_path):
-        return raw_path
-        
-    # Fallback check for different naming convention
-    # e.g. file.wsq.raw
-    if os.path.exists(wsq_path + ".raw"):
-        return wsq_path + ".raw"
-        
-    raise Exception(f"dwsq ran but output file not found for {wsq_path}")
 
 def convert_to_wsq(raw_path: str, output_path: str, width: int, height: int, bitrate: float = 2.25, depth: int = 8, ppi: int = 500) -> str:
     """
@@ -211,29 +176,32 @@ def convert_to_wsq(raw_path: str, output_path: str, width: int, height: int, bit
     Returns:
         Path to the generated WSQ file.
     """
-    # cwsq <rate> wsq <outfile> -r <infile> <w> <h> <depth> <ppi>
-    # Note: cwsq arguments might vary by version, but this is the standard NBIS usage.
-    
+    # cwsq <r bitrate> <outext> <image file> [-raw_in w,h,d,[ppi]] [comment file]
+    # w,h,d,ppi must be a single comma-joined token, not separate args.
+    ext = os.path.splitext(output_path)[1].lstrip(".")
+
     command = [
-        "cwsq", 
-        str(bitrate), 
-        "wsq", 
-        output_path, 
-        "-r", 
-        raw_path, 
-        str(width), 
-        str(height), 
-        str(depth), 
-        str(ppi)
+        "cwsq",
+        str(bitrate),
+        ext,
+        raw_path,
+        "-raw_in",
+        f"{width},{height},{depth},{ppi}"
     ]
-    
+
     stdout, stderr, returncode = run_command(command, cwd=os.path.dirname(raw_path))
-    
+
     if returncode != 0:
         raise Exception(f"cwsq failed: {stderr}")
-        
+
+    # cwsq names its output after raw_path (extension stripped) + outext,
+    # which may differ from the caller's requested output_path.
+    produced_path = os.path.splitext(raw_path)[0] + "." + ext
+    if produced_path != output_path and os.path.exists(produced_path):
+        os.replace(produced_path, output_path)
+
     if not os.path.exists(output_path):
         raise Exception(f"cwsq failed to create output file: {stderr}")
-        
+
     return output_path
 


### PR DESCRIPTION
**Issue**:
When opening an .EFT file for viewing or editing the finger print images would show a broken image link and logs would produce the errors:

Type 4, FGP 1: CGA = 1 (str: 1), Image size = 49723 bytes
 -> Saving as fp_1.wsq
WSQ Raw size mismatch for Type 4, FGP 1: 600296 != 600000 (800x750) Type 4, FGP 2: CGA = 1 (str: 1), Image size = 51462 bytes
  -> Saving as fp_2.wsq
WSQ Raw size mismatch for Type 4, FGP 2: 600296 != 600000 (800x750) Type 4, FGP 3: CGA = 1 (str: 1), Image size = 53638 bytes
  -> Saving as fp_3.wsq

**File changed:** WebApp/services/nbis_helper.py

Two bugs in the NBIS WSQ compress/decompress wrappers, both caused by passing the wrong CLI arguments to the compiled NBIS tools:

1. convert_wsq_to_raw() — decode path (this is what originally reported in issue #2   )
- Bug: Called dwsq raw <file> without the -raw_out flag. Per dwsq's real usage (dwsq <outext> <image file> [-raw_out]), that omission makes it write a NIST IHead file — a 288-byte text header + pixel data — instead of a bare pixmap, still named .raw. That fixed-size header was the exact "296 bytes too many" mismatch in your logs.
- Fix: One correct call: dwsq raw <file> -raw_out. Removed the three dead fallback attempts that never actually worked.
- Verified: reproduced the old 296-byte-too-large result and the new exact-match result side by side in the rebuilt container.

2. convert_to_wsq() — compress path (found incidentally while verifying above fix)
- Bug: Passed width, height, depth, ppi as four separate arguments. cwsq requires them as one comma-joined -raw_in w,h,d,ppi token, so the call always exceeded cwsq's max argument count and failed with a usage error — silently breaking the retry-compress path that shrinks EFTs over the 11.8MB ATF limit.
- Fix: Build the -raw_in token correctly, and handle cwsq's output-naming convention (it strips the input's extension and appends the new one, which can differ from the caller's requested output path) by renaming into place.
- Verified: full round-trip (raw → wsq → raw) via the app's actual Python functions inside the rebuilt container, confirming byte-for-byte size correctness at each step.